### PR TITLE
Use scl_source instead of symlinking

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -60,7 +60,7 @@ define ruby::gem (
   }
 
   exec { "install gem ${gem} for ${ruby}":
-    command => "/usr/bin/scl enable ${ruby} 'gem install ${gem} ${_v} ${_o}'",
-    unless  => "/usr/bin/scl enable ${ruby} 'gem list -i -l ${_v} ${gem}'",
+    command => "/usr/bin/scl enable ${ruby} -- gem install ${gem} ${_v} ${_o}",
+    unless  => "/usr/bin/scl enable ${ruby} -- gem list -i -l ${_v} ${gem}",
   }
 }

--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -60,8 +60,7 @@ define ruby::gem (
   }
 
   exec { "install gem ${gem} for ${ruby}":
-    command => "/usr/bin/scl enable ${ruby} -- gem install ${gem} ${_v} ${_o}",
-    unless  => "/usr/bin/scl enable ${ruby} -- gem list -i -l ${_v} ${gem}",
-    path    => "/usr/bin/scl enable ${ruby} -- echo \$PATH",
+    command => "/bin/bash -c 'source /opt/rh/${ruby}/enable; gem install ${gem} ${_v} ${_o}'",
+    unless  => "/bin/bash -c 'source /opt/rh/${ruby}/enable; gem list -i -l ${_v} ${gem}'",
   }
 }

--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -62,5 +62,6 @@ define ruby::gem (
   exec { "install gem ${gem} for ${ruby}":
     command => "/usr/bin/scl enable ${ruby} -- gem install ${gem} ${_v} ${_o}",
     unless  => "/usr/bin/scl enable ${ruby} -- gem list -i -l ${_v} ${gem}",
+    path    => "/usr/bin/scl enable ${ruby} -- echo \$PATH",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,7 @@ class ruby (
   # enable the default Ruby in all users' bash environments
   file { '/etc/profile.d/scl-ruby.sh':
     ensure  => present,
-    content => "source scl_source enable ${default_ruby}",
+    content => "source scl_source enable ${default_ruby}\n",
     require => Package["${default_ruby}-ruby"],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,8 +67,8 @@ class ruby (
 
   # enable the default Ruby in all users' bash environments
   file { '/etc/profile.d/scl-ruby.sh':
-    ensure  => link,
-    target  => "/opt/rh/${default_ruby}/enable",
+    ensure  => present,
+    content => "source scl_source enable ${default_ruby}",
     require => Package["${default_ruby}-ruby"],
   }
 


### PR DESCRIPTION
Following guidance from [this kb article](https://access.redhat.com/solutions/527703).

Allows activating a different ruby after logging in with the default ruby.
