### PR TITLE
RX-2283: export all rubies env settings

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   symlinks:
     ruby: "#{source_dir}"
   repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "rvm": "git://github.com/maestrodev/puppet-rvm.git"
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    rvm: "git://github.com/maestrodev/puppet-rvm.git"
+    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The full functionality of this module requires Hiera.
 To simply ensure that one or more Ruby versions are installed, use the base `ruby` class with an array of Ruby Software Collections names:
 
 ```
-  class { ruby: 
+  class { ruby:
     $rubies => [ 'ruby200', 'rh-ruby22', ],
   }
 ```
@@ -31,7 +31,7 @@ Gems can be installed system-wide on a per-Ruby basis.
   }
 ```
 
-Any Gem executable (binary or script) will be installed into `/opt/rh/<ruby>/root/usr/local/bin`, and that directory will be added to the `PATH` environment variable inside the relevant Software Collection enable script.  This ensures that Gem executables will be available when the Software Collection is enabled. 
+Any Gem executable (binary or script) will be installed into `/opt/rh/<ruby>/root/usr/local/bin`, and that directory will be added to the `PATH` environment variable inside the relevant Software Collection enable script.  This ensures that Gem executables will be available when the Software Collection is enabled.
 
 The default Gem installation options include `--no-ridoc` and `--no-rdoc`. If you wish to install documentation, you may do so:
 ```
@@ -85,6 +85,13 @@ The default for SCL gems is to pass `--no-ridoc` and `--no-rdoc` to the installa
         version: 1.7.3
         ridoc: true
         rdoc: true
+
+## Running Tests
+
+To run the Puppet spec tests, you will need to run the setup rake task first:
+
+1. `rake spec_clean && rake spec_prep` to set up your environment, *especially* if you updated .fixtures.yml
+2. `rake spec` from current directory to start the test
 
 # Contributing
 Pull requests are warmly welcomed!

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,11 +65,21 @@ class ruby (
   # in one shot
   ruby::usr_local { $rubies: }
 
-  # enable the default Ruby in all users' bash environments
-  file { '/etc/profile.d/scl-ruby.sh':
-    ensure  => link,
-    target  => "/opt/rh/${default_ruby}/enable",
-    require => Package["${default_ruby}-ruby"],
+  # enable Rubies in all users' bash environments
+  $_target_env = '/etc/profile.d/scl-ruby.sh'
+
+  concat { $_target_env:
+    owner => 'root',
+    group => 'root',
+    mode  => '0644',
+  }
+
+  reverse($rubies).each |Integer $id, String $version| {
+    concat::fragment { $version:
+      target => $_target_env,
+      source => "/opt/rh/${version}/enable",
+      order  => $id,
+    }
   }
 
   # get the default set of system gems

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,8 @@ class ruby (
     mode  => '0644',
   }
 
+  # reverse rubies order to make sure the first in the list is the default ruby
+  # refer to repo README for default ruby definition
   reverse($rubies).each |Integer $id, String $version| {
     concat::fragment { $version:
       target => $_target_env,

--- a/spec/classes/ruby_spec.rb
+++ b/spec/classes/ruby_spec.rb
@@ -27,17 +27,20 @@ describe 'ruby', :type => :class do
     end
   end
 
-  context 'multiple ruby envs enablement with correct order' do
+  context 'multiple ruby envs enablement with reverse order of the array' do
     let :params do
-      { :rubies => [ 'rh-ruby22', 'rh-ruby24' ] }
+      { :rubies => [ 'rh-ruby26', 'rh-ruby22', 'rh-ruby24', 'rh-ruby20' ] }
     end
     it { is_expected.to contain_concat__fragment("rh-ruby24").with(
-        'source'  => '/opt/rh/rh-ruby24/enable',
-        'target'  => '/etc/profile.d/scl-ruby.sh',
+        'source' => '/opt/rh/rh-ruby24/enable',
+        'target' => '/etc/profile.d/scl-ruby.sh',
+        'order'  => 1,
        )}
+
     it { is_expected.to contain_concat__fragment("rh-ruby22").with(
-        'source'  => '/opt/rh/rh-ruby22/enable',
-        'target'  => '/etc/profile.d/scl-ruby.sh',
+        'source' => '/opt/rh/rh-ruby22/enable',
+        'target' => '/etc/profile.d/scl-ruby.sh',
+        'order'  => 2,
        )}
   end
 end

--- a/spec/classes/ruby_spec.rb
+++ b/spec/classes/ruby_spec.rb
@@ -27,4 +27,17 @@ describe 'ruby', :type => :class do
     end
   end
 
+  context 'multiple ruby envs enablement with correct order' do
+    let :params do
+      { :rubies => [ 'rh-ruby22', 'rh-ruby24' ] }
+    end
+    it { is_expected.to contain_concat__fragment("rh-ruby24").with(
+        'source'  => '/opt/rh/rh-ruby24/enable',
+        'target'  => '/etc/profile.d/scl-ruby.sh',
+       )}
+    it { is_expected.to contain_concat__fragment("rh-ruby22").with(
+        'source'  => '/opt/rh/rh-ruby22/enable',
+        'target'  => '/etc/profile.d/scl-ruby.sh',
+       )}
+  end
 end

--- a/spec/classes/ruby_spec.rb
+++ b/spec/classes/ruby_spec.rb
@@ -29,18 +29,20 @@ describe 'ruby', :type => :class do
 
   context 'multiple ruby envs enablement with reverse order of the array' do
     let :params do
-      { :rubies => [ 'rh-ruby26', 'rh-ruby22', 'rh-ruby24', 'rh-ruby20' ] }
+      { :rubies => [ 'rh-zzoriginalfirstelement', 'rh-ruby22', 'rh-ruby24', 'rh-aaoriginallastelement' ] }
     end
+    it { is_expected.to contain_concat("/etc/profile.d/scl-ruby.sh") }
+    it { is_expected.to contain_concat__fragment("rh-aaoriginallastelement").with(
+        'order'  => 0,
+       )}
     it { is_expected.to contain_concat__fragment("rh-ruby24").with(
-        'source' => '/opt/rh/rh-ruby24/enable',
-        'target' => '/etc/profile.d/scl-ruby.sh',
         'order'  => 1,
        )}
-
     it { is_expected.to contain_concat__fragment("rh-ruby22").with(
-        'source' => '/opt/rh/rh-ruby22/enable',
-        'target' => '/etc/profile.d/scl-ruby.sh',
         'order'  => 2,
+       )}
+    it { is_expected.to contain_concat__fragment("rh-zzoriginalfirstelement").with(
+        'order'  => 3,
        )}
   end
 end


### PR DESCRIPTION
- Merge all rubies ENVs from different versions into one file and replace the soft link pointing to only default ruby. 
- Default ruby will be exported last, making it the first in export paths.

__Changes to Production__
/etc/profile.d/scl-ruby.sh will be a regular file instead of a soft link